### PR TITLE
Rework of the DTP module to fit into VMEM requests

### DIFF
--- a/include/dtp/dtp.h
+++ b/include/dtp/dtp.h
@@ -16,6 +16,8 @@ extern "C"
     /** Opaque handle to a DTP sesssion */
     typedef struct dtp_t dtp_t;
 
+    typedef struct dtp_async_api_s dtp_async_api_t;
+
     /** Returned by most of DTP API calls*/
     typedef enum
     {
@@ -279,6 +281,7 @@ extern "C"
 /*
 #pragma region Simplified Public API
  */
+    extern int dtp_vmem_server_main(bool *keep_running, dtp_async_api_t *api);
     extern int dtp_server_main(bool *keep_running);
     extern int dtp_client_main(uint32_t server, uint16_t max_throughput, uint8_t timeout, uint8_t payload_id, uint16_t mtu, bool resume, dtp_t **session);
 

--- a/include/dtp/dtp_async_api.h
+++ b/include/dtp/dtp_async_api.h
@@ -10,7 +10,7 @@ typedef struct dtp_msg_s {
     uint16_t node;
     uint64_t vaddr;
     uint32_t size;
-    dtp_meta_req_v2_t meta;
+    dtp_meta_req_t meta;
 } dtp_msg_t;
 
 typedef struct dtp_async_api_s dtp_async_api_t;

--- a/include/dtp/dtp_async_api.h
+++ b/include/dtp/dtp_async_api.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "dtp_protocol.h"
+
+typedef struct dtp_msg_s {
+    uint32_t msg;
+    uint16_t node;
+    uint64_t vaddr;
+    uint32_t size;
+    dtp_meta_req_t meta;
+} dtp_msg_t;
+
+typedef struct dtp_async_api_s dtp_async_api_t;
+
+typedef void dtp_async_recv_message_t(dtp_async_api_t *me, dtp_msg_t *msg);
+typedef bool dtp_async_send_message_t(dtp_async_api_t *me, dtp_msg_t *msg);
+typedef uint32_t dtp_async_read_data_t(dtp_async_api_t *me, uint8_t *to_addr, uint64_t from_vaddr, uint32_t size);
+
+typedef struct dtp_async_api_s {
+    dtp_async_recv_message_t *recv;
+    dtp_async_send_message_t *send;
+    dtp_async_read_data_t *read;
+    void *context;
+} dtp_async_api_t;

--- a/include/dtp/dtp_async_api.h
+++ b/include/dtp/dtp_async_api.h
@@ -10,7 +10,7 @@ typedef struct dtp_msg_s {
     uint16_t node;
     uint64_t vaddr;
     uint32_t size;
-    dtp_meta_req_t meta;
+    dtp_meta_req_v2_t meta;
 } dtp_msg_t;
 
 typedef struct dtp_async_api_s dtp_async_api_t;

--- a/include/dtp/dtp_protocol.h
+++ b/include/dtp/dtp_protocol.h
@@ -43,7 +43,7 @@ extern "C"
         uint32_t throughput; /** max server throughput in KB/second */
         uint8_t nof_intervals; /** Number of segments to transfer, see the intervals below */
         uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
-        interval_v2_t intervals[0]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
+        interval_v2_t intervals[8]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
     } dtp_meta_req_v2_t;
 
     typedef struct {

--- a/include/dtp/dtp_protocol.h
+++ b/include/dtp/dtp_protocol.h
@@ -22,6 +22,11 @@ extern "C"
         uint32_t end;
     } interval_t;
 
+    typedef struct {
+        uint64_t start;
+        uint32_t length;
+    } interval_v2_t;
+
     /** Transfer request */
     typedef struct
     {
@@ -32,6 +37,14 @@ extern "C"
         uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
         interval_t intervals[19]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
     } dtp_meta_req_t;
+
+    typedef struct
+    {
+        uint32_t throughput; /** max server throughput in KB/second */
+        uint8_t nof_intervals; /** Number of segments to transfer, see the intervals below */
+        uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
+        interval_v2_t intervals[0]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
+    } dtp_meta_req_v2_t;
 
     typedef struct {
         uint16_t destination; /** Destination port */

--- a/include/dtp/dtp_protocol.h
+++ b/include/dtp/dtp_protocol.h
@@ -28,7 +28,7 @@ extern "C"
         uint32_t throughput; /** max server throughput in KB/second */
         // uint8_t timeout; /** number of seconds with no received packets that will stop the session */
         uint8_t nof_intervals; /** Number of segments to transfer, see the intervals below */
-        uint8_t payload_id; /** Payload ID, conceptual identifer for the payload to retrieve, semantic is entirely server-specific */
+        uint8_t payload_id; /** Payload ID, conceptual identifier for the payload to retrieve, semantic is entirely server-specific */
         uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
         interval_t intervals[19]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
     } dtp_meta_req_t;

--- a/include/dtp/dtp_protocol.h
+++ b/include/dtp/dtp_protocol.h
@@ -22,11 +22,6 @@ extern "C"
         uint32_t end;
     } interval_t;
 
-    typedef struct {
-        uint64_t start;
-        uint32_t length;
-    } interval_v2_t;
-
     /** Transfer request */
     typedef struct
     {
@@ -35,16 +30,8 @@ extern "C"
         uint8_t nof_intervals; /** Number of segments to transfer, see the intervals below */
         uint8_t payload_id; /** Payload ID, conceptual identifier for the payload to retrieve, semantic is entirely server-specific */
         uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
-        interval_t intervals[19]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
+        interval_t intervals[8]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
     } dtp_meta_req_t;
-
-    typedef struct
-    {
-        uint32_t throughput; /** max server throughput in KB/second */
-        uint8_t nof_intervals; /** Number of segments to transfer, see the intervals below */
-        uint16_t mtu; /** MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
-        interval_v2_t intervals[8]; /** list of start-stop pairs to transfer, number is set by nof_intervals above */
-    } dtp_meta_req_v2_t;
 
     typedef struct {
         uint16_t destination; /** Destination port */

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "dtp/dtp_protocol.h"
+#include "vmem/vmem_server.h"
+
+#define VMEM_SERVER_START_DTP_TRANSFER (VMEM_SERVER_USER_TYPES + 0)
+
+typedef struct {
+    vmem_request_hdr_t hdr;
+    dtp_meta_req_v2_t meta;
+} __attribute__((packed)) dtp_vmem_request_t;

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -13,3 +13,5 @@ typedef struct {
     uint32_t size;
     dtp_meta_req_t meta;
 } __attribute__((packed)) dtp_vmem_request_t;
+
+extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp);

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -9,5 +9,7 @@
 
 typedef struct {
     vmem_request_hdr_t hdr;
-    dtp_meta_req_v2_t meta;
+    uint64_t vaddr;
+    uint32_t size;
+    dtp_meta_req_t meta;
 } __attribute__((packed)) dtp_vmem_request_t;

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -2,30 +2,5 @@
 
 #include <stdint.h>
 
-#include "dtp/dtp_protocol.h"
-#include "vmem/vmem_server.h"
-
-#define VMEM_SERVER_DTP_REQUEST (VMEM_SERVER_USER_TYPES + 0)
-
-#define DTP_REQUEST_START_TRANSFER 0x00
-#define DTP_REQUEST_STOP_TRANSFER 0x01
-
-typedef struct {
-    uint32_t session_id;
-    uint64_t vaddr;
-    uint32_t size;
-    dtp_meta_req_t meta;
-} __attribute__((__packed__)) dtp_start_req_t;
-
-typedef struct {
-    uint32_t session_id;
-} __attribute__((__packed__)) dtp_stop_req_t;
-        
-typedef struct {
-    vmem_request_hdr_t hdr;
-    uint8_t type;
-    uint8_t body[0];
-} __attribute__((__packed__)) dtp_vmem_request_t;
-
 extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp, uint32_t thrughput);
 extern int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp);

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
-extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp, uint32_t thrughput);
+#include "csp/csp.h"
+#include "dtp/dtp_protocol.h"
+
+typedef bool vmem_dtp_on_data_t(dtp_t *session, csp_packet_t *packet);
+
+extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, vmem_dtp_on_data_t *on_data, int version, int use_rdp, uint32_t thrughput);
 extern int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp);

--- a/include/dtp/dtp_vmem_client.h
+++ b/include/dtp/dtp_vmem_client.h
@@ -5,13 +5,27 @@
 #include "dtp/dtp_protocol.h"
 #include "vmem/vmem_server.h"
 
-#define VMEM_SERVER_START_DTP_TRANSFER (VMEM_SERVER_USER_TYPES + 0)
+#define VMEM_SERVER_DTP_REQUEST (VMEM_SERVER_USER_TYPES + 0)
+
+#define DTP_REQUEST_START_TRANSFER 0x00
+#define DTP_REQUEST_STOP_TRANSFER 0x01
 
 typedef struct {
-    vmem_request_hdr_t hdr;
+    uint32_t session_id;
     uint64_t vaddr;
     uint32_t size;
     dtp_meta_req_t meta;
-} __attribute__((packed)) dtp_vmem_request_t;
+} __attribute__((__packed__)) dtp_start_req_t;
 
-extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp);
+typedef struct {
+    uint32_t session_id;
+} __attribute__((__packed__)) dtp_stop_req_t;
+        
+typedef struct {
+    vmem_request_hdr_t hdr;
+    uint8_t type;
+    uint8_t body[0];
+} __attribute__((__packed__)) dtp_vmem_request_t;
+
+extern int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp, uint32_t thrughput);
+extern int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp);

--- a/include/dtp/dtp_vmem_server.h
+++ b/include/dtp/dtp_vmem_server.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "dtp/dtp_protocol.h"
+#include "vmem/vmem_server.h"
+
+#define VMEM_SERVER_DTP_REQUEST (VMEM_SERVER_USER_TYPES + 0)
+
+#define DTP_REQUEST_START_TRANSFER 0x00
+#define DTP_REQUEST_STOP_TRANSFER 0x01
+
+typedef struct {
+    uint32_t session_id;
+    uint64_t vaddr;
+    uint32_t size;
+    dtp_meta_req_t meta;
+} __attribute__((__packed__)) dtp_start_req_t;
+
+typedef struct {
+    uint32_t session_id;
+} __attribute__((__packed__)) dtp_stop_req_t;
+        
+typedef struct {
+    vmem_request_hdr_t hdr;
+    uint8_t type;
+    uint8_t body[0];
+} __attribute__((__packed__)) dtp_vmem_request_t;
+
+extern void dtp_vmem_server_task(void * param);

--- a/include/dtp/platform.h
+++ b/include/dtp/platform.h
@@ -19,8 +19,9 @@ extern "C"
     typedef struct
     {
         uint32_t size;
-        uint32_t (*read)(uint8_t payload_id, uint32_t offset, void *output, uint32_t size);
-        void (*completed)(uint8_t payload_id, uint32_t size);
+        uint32_t (*read)(uint8_t payload_id, uint32_t offset, void *output, uint32_t size, void *context);
+        void (*completed)(uint8_t payload_id, uint32_t size, void *context);
+        void *context;
     } dtp_payload_meta_t;
 
     /**

--- a/include/dtp/platform.h
+++ b/include/dtp/platform.h
@@ -18,6 +18,7 @@ extern "C"
      */
     typedef struct
     {
+        uint64_t base;
         uint32_t size;
         uint32_t (*read)(uint8_t payload_id, uint32_t offset, void *output, uint32_t size, void *context);
         void (*completed)(uint8_t payload_id, uint32_t size, void *context);

--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,8 @@ if doxygen.found()
                               build_by_default: false)
 endif
 
-dtp_client_dep = declare_dependency(include_directories : include, link_with : dtp_client_lib, dependencies: dtp_lib_dep).as_link_whole()
-dtp_server_dep = declare_dependency(include_directories : include, link_with : dtp_server_lib, dependencies: dtp_lib_dep).as_link_whole()
+dtp_client_dep = declare_dependency(include_directories : include, link_with : dtp_client_lib, dependencies: dtp_lib_dep)
+dtp_server_dep = declare_dependency(include_directories : include, link_with : dtp_server_lib, dependencies: dtp_lib_dep)
 
 if not meson.is_subproject()
     subdir('tests')

--- a/src/dtp_server.c
+++ b/src/dtp_server.c
@@ -5,6 +5,7 @@
 #include "dtp/dtp_protocol.h"
 #include "dtp/dtp_log.h"
 #include "dtp/dtp_os_hal.h"
+#include "dtp/dtp_async_api.h"
 
 static void dtp_server_run(bool *keep_running)
 {
@@ -60,6 +61,63 @@ static uint32_t compute_transfer_size(dtp_server_transfer_ctx_t *ctx) {
     return size;
 }
 
+typedef struct dtp_payload_vmem_transfer_s {
+    dtp_msg_t *msg;
+    dtp_async_api_t *api;
+} dtp_payload_vmem_transfer_t;
+
+static uint32_t dtp_payload_vmem_read(uint8_t payload_id, uint32_t offset, void *output, uint32_t size, void *context) {
+
+    dtp_payload_vmem_transfer_t *txfr = (dtp_payload_vmem_transfer_t *)context;
+
+    (*txfr->api->read)(txfr->api, output, txfr->msg->vaddr + offset, size);
+
+    return size;
+} 
+
+static void dtp_vmem_server_run(bool *keep_running, dtp_async_api_t *api)
+{
+
+    dtp_server_transfer_ctx_t server_transfer_ctx;
+
+    dbg_log("Starting DTP VMEM Server task.\n");
+
+    /* Wait for connections and then process packets on the connection */
+    while (*keep_running)
+    {
+        dtp_msg_t msg;
+
+        /* Wait for in coming messages on the queue */
+        dbg_log("Waiting for instruction on receive queue...");
+        (*api->recv)(api, &msg);
+
+        switch (msg.msg) {
+            case 0x01: /* DTP_START_VMEM_TRANSFER */
+            {
+                dbg_log("Got meta data request thru DTP start VMEM transfer");
+
+                server_transfer_ctx.payload_meta.size = msg.size;
+                server_transfer_ctx.size_in_bytes = compute_transfer_size(&server_transfer_ctx);
+
+                dtp_payload_vmem_transfer_t transfer_obj = { .msg = &msg, .api = api };
+                server_transfer_ctx.payload_meta.context = &transfer_obj;
+                server_transfer_ctx.payload_meta.read = dtp_payload_vmem_read;
+                server_transfer_ctx.payload_meta.completed = NULL;
+                server_transfer_ctx.destination = msg.node;
+                server_transfer_ctx.keep_running = keep_running;
+                /* Start the actual transmission of data. This will block until done.
+                It can be stopped by setting the 'keep_running' flag on the object
+                passed on to the process. */
+                start_sending_data(&server_transfer_ctx);
+
+                dbg_log("Transfer done");
+            }
+            break;
+        }
+    }
+    dbg_log("Bye");
+}
+
 typedef struct dtp_server_transfer_s {
     bool keep_running;
     uint32_t bytes_sent;
@@ -101,7 +159,7 @@ static bool dtp_server_poll_loop(uint32_t op, void *context) {
         memcpy(packet->data, &transfer->bytes_sent, sizeof(uint32_t));
 
         // Get the packet payload data from the "user"
-        data_read =transfer->ctx->payload_meta.read(transfer->ctx->request.payload_id, transfer->bytes_sent, packet->data + sizeof(uint32_t), packet->length - sizeof(uint32_t));
+        data_read = transfer->ctx->payload_meta.read(transfer->ctx->request.payload_id, transfer->bytes_sent, packet->data + sizeof(uint32_t), packet->length - sizeof(uint32_t), transfer->ctx->payload_meta.context);
         if (data_read == 0){
             dbg_warn("could not read data from user");
             break;
@@ -113,7 +171,7 @@ static bool dtp_server_poll_loop(uint32_t op, void *context) {
 
         // TODO: The priority parameter might need to be adjusted according to payload meta-data, though it may not have any impact
         // on actual speed transfer at all.
-        csp_sendto(CSP_PRIO_NORM, transfer->ctx->destination, 8, 0, 0, packet);
+        csp_sendto(CSP_PRIO_NORM, transfer->ctx->destination, 8 /* DTP DATA PORT */, 0, 0, packet);
         transfer->nof_csp_packets++;
         pkt_cnt++;
     }
@@ -177,7 +235,7 @@ extern dtp_result start_sending_data(dtp_server_transfer_ctx_t *ctx)
 
     /* Signal completion to the user, if possible */
     if (transfer.ctx->payload_meta.completed) {
-        (*transfer.ctx->payload_meta.completed)(transfer.ctx->request.payload_id, transfer.bytes_sent);
+        (*transfer.ctx->payload_meta.completed)(transfer.ctx->request.payload_id, transfer.bytes_sent, transfer.ctx->payload_meta.context);
     }
 
     return result;
@@ -211,5 +269,11 @@ csp_packet_t *setup_server_transfer(dtp_server_transfer_ctx_t *ctx, uint16_t dst
 int dtp_server_main(bool *keep_running)
 {
     dtp_server_run(keep_running);
+    return 0;
+}
+
+int dtp_vmem_server_main(bool *keep_running, dtp_async_api_t *api)
+{
+    dtp_vmem_server_run(keep_running, api);
     return 0;
 }

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -9,28 +9,7 @@
 #include "dtp/dtp_vmem_server.h"
 #include "dtp/dtp_session.h"
 
-#define STRINGIFY_IMPL(arg) #arg
-#define STRINGIFY(arg) STRINGIFY_IMPL(arg)
-
-#define CSI "\x1B["
-#define SAVE_CURPOS CSI "s"
-#define RESTORE_CURPOS CSI "u"
-#define ERASE_LINE CSI "K"
-#define SET_CURPOS CSI "%u;%uH"
-#define SCROLL_UP CSI "S"
-#define SCROLL_DOWN CSI "T"
-
-static bool vmem_dtp_on_data_packet(dtp_t *session, csp_packet_t *packet)
-{
-    printf(SAVE_CURPOS);
-    printf(SET_CURPOS, 0, 0);
-    printf(ERASE_LINE);
-    printf("Receiving: [%"PRIu32":%"PRIu32"]\n", packet->data32[0], (uint32_t)(packet->data32[0] + packet->length - sizeof(uint32_t) - 1));
-    printf(RESTORE_CURPOS);
-    return true;
-}
-
-int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp, uint32_t thrughput)
+int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, vmem_dtp_on_data_t *on_data, int version, int use_rdp, uint32_t thrughput)
 {
     uint8_t intervals = 1;
 
@@ -112,7 +91,8 @@ int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, 
     }
 
     session->payload_size = length;
-    session->hooks.on_data_packet = vmem_dtp_on_data_packet;
+    session->hooks.on_data_packet = on_data;
+    session->hooks.hook_ctx = NULL;
     res = start_receiving_data(session);
     if (res != DTP_OK) {
         printf("Error receiving data: %d\n", res);

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -1,0 +1,67 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <endian.h>
+
+#include "csp/arch/csp_time.h"
+#include "csp/csp.h"
+//#include "vmem/vmem_server.h"
+
+#include "dtp/dtp_vmem_client.h"
+
+int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp)
+{
+    uint32_t time_begin = csp_get_ms();
+    uint8_t intervals = 1;
+
+    /* Establish RDP connection */
+    uint32_t opts = CSP_O_CRC32;
+    if (use_rdp) {
+        opts |= CSP_O_RDP;
+    }
+    csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, opts);
+    if (conn == NULL) {
+        return -1;
+    }
+
+    uint16_t packet_len = sizeof(dtp_vmem_request_t) + (sizeof(interval_v2_t) * intervals);
+    csp_packet_t * packet = csp_buffer_get(packet_len);
+    if (packet == NULL) {
+        return -1;
+    }
+
+    dtp_vmem_request_t * request = (void *) packet->data;
+    /* VMEM request header */
+    request->hdr.type = VMEM_SERVER_START_DTP_TRANSFER;
+    request->hdr.version = VMEM_VERSION;
+    
+    /* DTP specifics */
+    request->meta.throughput = 1024; /* 1 MB/s */
+    request->meta.mtu = VMEM_SERVER_MTU; /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
+    request->meta.nof_intervals = intervals; /* Only one interval, since this is the initial one */
+    request->meta.intervals[0].start = htobe64(address);
+    request->meta.intervals[0].length = htobe32(length);
+
+    /* Set the CSP packet length */
+    packet->length = packet_len;
+
+    /* Send the request */
+    csp_send(conn, packet);
+
+    /* Now we expect the VMEM server at the other end to start DTP transmission */
+    uint32_t count = 0;
+    int dotcount = 0;
+
+    while(1) { 
+
+    }
+
+
+    csp_close(conn);
+
+    uint32_t time_total = csp_get_ms() - time_begin;
+
+    printf("  Downloaded %u bytes in %.03f s at %u Bps\n", (unsigned int) count, time_total / 1000.0, (unsigned int) (count / ((float)time_total / 1000.0)) );
+
+    return count;
+
+}

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -15,7 +15,7 @@
 #define SAVE_CURPOS CSI "s"
 #define RESTORE_CURPOS CSI "u"
 #define ERASE_LINE CSI "K"
-#define SET_CURPOS CSI "%"PRIu32";%"PRIu32"H"
+#define SET_CURPOS CSI "%u;%uH"
 #define SCROLL_UP CSI "S"
 #define SCROLL_DOWN CSI "T"
 
@@ -57,13 +57,13 @@ int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, 
     /* DTP request */
     vmem_request->type = DTP_REQUEST_START_TRANSFER;
     dtp_start_req_t *request = (dtp_start_req_t *)&vmem_request->body[0];
-    request->session_id = 0; /* TODO: use the session ID */
+    request->session_id = htobe32(0); /* TODO: use the session ID */
     request->vaddr = htobe64(address);
     request->size = htobe32(length);
     
     /* DTP specifics */
-    request->meta.throughput = thrughput;
-    request->meta.mtu = VMEM_SERVER_MTU; /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
+    request->meta.throughput = htobe32(thrughput);
+    request->meta.mtu = htobe16(VMEM_SERVER_MTU); /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
     request->meta.nof_intervals = intervals; /* Only one interval, since this is the initial one */
     request->meta.intervals[0].start = htobe32(0);
     request->meta.intervals[0].end = htobe32(UINT32_MAX);
@@ -150,7 +150,7 @@ int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp) {
     /* DTP request */
     vmem_request->type = DTP_REQUEST_STOP_TRANSFER;
     dtp_stop_req_t *request = (dtp_stop_req_t *)&vmem_request->body[0];
-    request->session_id = 0; /* TODO: use the session ID */
+    request->session_id = htobe32(0);; /* TODO: use the session ID */
 
     /* Set the CSP packet length */
     packet->length = packet_len;
@@ -159,4 +159,6 @@ int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp) {
     csp_send(conn, packet);
 
     csp_close(conn);
+
+    return 0;
 }

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -4,13 +4,33 @@
 
 #include "csp/arch/csp_time.h"
 #include "csp/csp.h"
-//#include "vmem/vmem_server.h"
-
+#include "vmem/vmem_server.h"
 #include "dtp/dtp_vmem_client.h"
+#include "dtp/dtp_session.h"
 
-int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp)
+#define STRINGIFY_IMPL(arg) #arg
+#define STRINGIFY(arg) STRINGIFY_IMPL(arg)
+
+#define CSI "\x1B["
+#define SAVE_CURPOS CSI "s"
+#define RESTORE_CURPOS CSI "u"
+#define ERASE_LINE CSI "K"
+#define SET_CURPOS CSI "%"PRIu32";%"PRIu32"H"
+#define SCROLL_UP CSI "S"
+#define SCROLL_DOWN CSI "T"
+
+static bool vmem_dtp_on_data_packet(dtp_t *session, csp_packet_t *packet)
 {
-    uint32_t time_begin = csp_get_ms();
+    printf(SAVE_CURPOS);
+    printf(SET_CURPOS, 0, 0);
+    printf(ERASE_LINE);
+    printf("Receiving: [%"PRIu32":%"PRIu32"]\n", packet->data32[0], (uint32_t)(packet->data32[0] + packet->length - sizeof(uint32_t) - 1));
+    printf(RESTORE_CURPOS);
+    return true;
+}
+
+int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp, uint32_t thrughput)
+{
     uint8_t intervals = 1;
 
     /* Establish RDP connection */
@@ -23,22 +43,27 @@ int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, 
         return -1;
     }
 
-    uint16_t packet_len = sizeof(dtp_vmem_request_t);
+    uint16_t packet_len = sizeof(dtp_vmem_request_t) + sizeof(dtp_start_req_t);
     csp_packet_t * packet = csp_buffer_get(packet_len);
     if (packet == NULL) {
         return -1;
     }
 
-    dtp_vmem_request_t * request = (void *) packet->data;
     /* VMEM request header */
-    request->hdr.type = VMEM_SERVER_START_DTP_TRANSFER;
-    request->hdr.version = version;
-    
-    /* DTP specifics */
-    request->meta.throughput = 1024; /* 1 MB/s */
-    request->meta.mtu = VMEM_SERVER_MTU; /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
+    dtp_vmem_request_t *vmem_request = (dtp_vmem_request_t *)&packet->data[0];
+    vmem_request->hdr.type = VMEM_SERVER_DTP_REQUEST;
+    vmem_request->hdr.version = version;
+
+    /* DTP request */
+    vmem_request->type = DTP_REQUEST_START_TRANSFER;
+    dtp_start_req_t *request = (dtp_start_req_t *)&vmem_request->body[0];
+    request->session_id = 0; /* TODO: use the session ID */
     request->vaddr = htobe64(address);
     request->size = htobe32(length);
+    
+    /* DTP specifics */
+    request->meta.throughput = thrughput;
+    request->meta.mtu = VMEM_SERVER_MTU; /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
     request->meta.nof_intervals = intervals; /* Only one interval, since this is the initial one */
     request->meta.intervals[0].start = htobe32(0);
     request->meta.intervals[0].end = htobe32(UINT32_MAX);
@@ -49,16 +74,89 @@ int vmem_dtp_download(int node, int timeout, uint64_t address, uint32_t length, 
     /* Send the request */
     csp_send(conn, packet);
 
-    /* Now we expect the VMEM server at the other end to start DTP transmission */
-    uint32_t count = 0;
-    int dotcount = 0;
-
     csp_close(conn);
 
-    uint32_t time_total = csp_get_ms() - time_begin;
+    dtp_t *session = NULL;
+    dtp_result res = DTP_OK;
 
-    printf("  Downloaded %u bytes in %.03f s at %u Bps\n", (unsigned int) count, time_total / 1000.0, (unsigned int) (count / ((float)time_total / 1000.0)) );
+    session = dtp_acquire_session();
+    dtp_params remote_cfg = { .remote_cfg.node = node };
+    res = dtp_set_opt(session, DTP_REMOTE_CFG, &remote_cfg);
+    if (DTP_OK != res) {
+        goto get_out_please;
+    }
 
-    return count;
+    remote_cfg.throughput.value = thrughput;
+    res = dtp_set_opt(session, DTP_THROUGHPUT_CFG, &remote_cfg);
+    if (DTP_OK != res) {
+        goto get_out_please;
+    }
 
+    remote_cfg.timeout.value = timeout;
+    res = dtp_set_opt(session, DTP_TIMEOUT_CFG, &remote_cfg);
+    if (DTP_OK != res) {
+        goto get_out_please;
+    }
+    
+    remote_cfg.payload_id.value = UINT8_MAX;
+    res = dtp_set_opt(session, DTP_PAYLOAD_ID_CFG, &remote_cfg);
+    if (DTP_OK != res) {
+        goto get_out_please;
+    }
+    
+    remote_cfg.mtu.value = VMEM_SERVER_MTU;
+    res = dtp_set_opt(session, DTP_MTU_CFG, &remote_cfg);
+    if (DTP_OK != res) {
+        goto get_out_please;
+    }
+
+    session->payload_size = length;
+    session->hooks.on_data_packet = vmem_dtp_on_data_packet;
+    res = start_receiving_data(session);
+    if (res != DTP_OK) {
+        printf("Error receiving data: %d\n", res);
+    }
+
+get_out_please:
+    dtp_release_session(session);
+
+    return 0;
+
+}
+
+int vmem_dtp_stop_download(int node, int timeout, int version, int use_rdp) {
+
+    /* Establish RDP connection */
+    uint32_t opts = CSP_O_CRC32;
+    if (use_rdp) {
+        opts |= CSP_O_RDP;
+    }
+    csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, opts);
+    if (conn == NULL) {
+        return -1;
+    }
+
+    uint16_t packet_len = sizeof(dtp_vmem_request_t) + sizeof(dtp_stop_req_t);
+    csp_packet_t * packet = csp_buffer_get(packet_len);
+    if (packet == NULL) {
+        return -1;
+    }
+
+    /* VMEM request header */
+    dtp_vmem_request_t *vmem_request = (dtp_vmem_request_t *)&packet->data[0];
+    vmem_request->hdr.type = VMEM_SERVER_DTP_REQUEST;
+    vmem_request->hdr.version = version;
+
+    /* DTP request */
+    vmem_request->type = DTP_REQUEST_STOP_TRANSFER;
+    dtp_stop_req_t *request = (dtp_stop_req_t *)&vmem_request->body[0];
+    request->session_id = 0; /* TODO: use the session ID */
+
+    /* Set the CSP packet length */
+    packet->length = packet_len;
+
+    /* Send the request */
+    csp_send(conn, packet);
+
+    csp_close(conn);
 }

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -6,6 +6,7 @@
 #include "csp/csp.h"
 #include "vmem/vmem_server.h"
 #include "dtp/dtp_vmem_client.h"
+#include "dtp/dtp_vmem_server.h"
 #include "dtp/dtp_session.h"
 
 #define STRINGIFY_IMPL(arg) #arg

--- a/src/dtp_vmem_server.c
+++ b/src/dtp_vmem_server.c
@@ -1,0 +1,122 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "csp/csp.h"
+
+#include "dtp/dtp_async_api.h"
+#include "dtp/dtp_vmem_server.h"
+
+#include "utils/message_queue.h"
+
+#include "vmem/vmem.h"
+#include "vmem/vmem_server.h"
+
+typedef struct dtp_vmem_context_s {
+    bool carryon;
+    message_queue_t queue;
+    uint8_t queue_storage[10 * sizeof(dtp_msg_t)];
+    vmem_handler_obj_t vmem_handler;
+} dtp_vmem_context_t;
+
+static int vmem_dtp_request_handler(csp_conn_t *conn, csp_packet_t *packet, void *context) {
+
+    /* This method gets called when the VMEM server receives a request on its port
+    with the request type of 0x80. We need to unpack the DTP meta data and setup
+    the actual transfer. When the DTP transfer has been started, it will send packets
+    to port 8 at the initiating node. */
+
+    dtp_vmem_request_t *vmem_request = (void *)packet->data;
+    dtp_msg_t msg;
+    dtp_vmem_context_t *vmem_context = (dtp_vmem_context_t *)context;
+
+    switch (vmem_request->type) {
+        case  DTP_REQUEST_START_TRANSFER:
+        {
+            dtp_start_req_t *request = (dtp_start_req_t *)&vmem_request->body[0];
+            uint32_t chunk_size = be16toh(request->meta.mtu) - sizeof(uint32_t);
+
+            printf("Received DTP VMEM start transfer request.\n");
+            printf("\tSession ID: %"PRIu32"\n", be32toh(request->session_id));
+            printf("\tMTU: %"PRIu16"\n", be16toh(request->meta.mtu));
+            msg.meta.mtu = be16toh(request->meta.mtu);
+            msg.meta.throughput = be32toh(request->meta.throughput);
+            msg.meta.payload_id = request->meta.payload_id;
+            msg.meta.nof_intervals = request->meta.nof_intervals;
+            printf("\tStart address: 0x%016"PRIX64"\n", be64toh(request->vaddr));
+            printf("\tSize: %"PRIu32"\n", be32toh(request->size));
+            printf("\tChunk size: %"PRIu32"\n", chunk_size);
+            printf("\tnof_intervals: %"PRIu8"\n", request->meta.nof_intervals);
+            for (uint8_t i=0;i<request->meta.nof_intervals;i++) {
+                interval_t interval;
+                memcpy(&interval, &request->meta.intervals[i], sizeof(interval_t));
+                interval.start = be32toh(interval.start);
+                interval.end = be32toh(interval.end);
+                msg.meta.intervals[i] = interval;
+                printf("\tinterval[%d]: %"PRIu32" - %"PRIu32"\n", i, interval.start, interval.end);
+            }
+
+            msg.msg = 0x01; /* DTP_START_VMEM_TRANSFER */
+            msg.node = csp_conn_src(conn);
+            msg.vaddr = be64toh(request->vaddr);
+            msg.size = be32toh(request->size);
+
+            message_queue_send(&vmem_context->queue, &msg);
+        }
+        break;
+
+        case DTP_REQUEST_STOP_TRANSFER:
+        {
+            dtp_stop_req_t *request = (dtp_stop_req_t *)&vmem_request->body[0];
+            printf("Received DTP VMEM stop transfer request.\n");
+            printf("\tSession ID: %"PRIu32"\n", be32toh(request->session_id));
+
+            /* Stop the transfer */
+            printf("Stopping the DTP transfer...\n");
+            vmem_context->carryon = false;
+        }
+        break;
+    }
+
+    csp_buffer_free(packet);
+
+    return 0;
+
+}
+
+static void async_recv(dtp_async_api_t *me, dtp_msg_t *msg) {
+
+    message_queue_t *queue = (message_queue_t *)me->context;
+    message_queue_receive(queue, msg);
+}
+
+static uint32_t async_vmem_read(dtp_async_api_t *me, uint8_t *to_addr, uint64_t from_vaddr, uint32_t size) {
+
+    vmem_read(to_addr, from_vaddr, size);
+
+    return size;
+}
+
+void dtp_vmem_server_task(void * param) {
+
+    static dtp_vmem_context_t dtp_vmem_context;
+    static dtp_async_api_t dtp_api = {
+        .recv = async_recv,
+        .send = NULL,
+        .read = async_vmem_read,
+        .context = &dtp_vmem_context.queue,
+    };
+
+    /* Set the task to be carrying on by default */
+    dtp_vmem_context.carryon = true;
+
+    /* Create the message queue to be used for async task communication */
+    message_queue_create(&dtp_vmem_context.queue, sizeof(dtp_msg_t), 10, &dtp_vmem_context.queue_storage[0]);
+
+    /* Hook up the VMEM request type for the DTP server */
+    vmem_server_bind_type(0x80 /* VMEM_SERVER_DTP_REQUEST */, vmem_dtp_request_handler, &dtp_vmem_context.vmem_handler, &dtp_vmem_context);
+
+    /* Start the DTP VMEM server main task - it will newer return */
+    dtp_vmem_server_main(&dtp_vmem_context.carryon, &dtp_api);
+
+}

--- a/src/dtp_vmem_server.c
+++ b/src/dtp_vmem_server.c
@@ -7,7 +7,7 @@
 #include "dtp/dtp_async_api.h"
 #include "dtp/dtp_vmem_server.h"
 
-#include "message_queue.h"
+#include "ossi/message_queue.h"
 
 #include "vmem/vmem.h"
 #include "vmem/vmem_server.h"

--- a/src/dtp_vmem_server.c
+++ b/src/dtp_vmem_server.c
@@ -7,7 +7,7 @@
 #include "dtp/dtp_async_api.h"
 #include "dtp/dtp_vmem_server.h"
 
-#include "utils/message_queue.h"
+#include "message_queue.h"
 
 #include "vmem/vmem.h"
 #include "vmem/vmem_server.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,9 +14,9 @@ server_src = [
     'payload_api.c'
 ]
 
-csp_dep = dependency('csp', fallback:['csp', 'csp_dep']).partial_dependency(links: false, includes: true)
-param_dep = dependency('param', fallback:['param', 'param_dep']).partial_dependency(links: false, includes: true)
-ossi_dep = dependency('ossi', fallback:['ossi', 'ossi_dep']).partial_dependency(links: false, includes: true)
+csp_dep = dependency('csp', fallback:['csp', 'csp_dep'])
+param_dep = dependency('param', fallback:['param', 'param_dep'])
+ossi_dep = dependency('ossi', fallback:['ossi', 'ossi_dep'])
 
 lib_deps = [csp_dep, param_dep, ossi_dep]
 
@@ -24,7 +24,7 @@ dtp_lib = library('dtp', lib_src, include_directories: [include, include_directo
 dtp_lib_dep = declare_dependency(include_directories : include, link_with : dtp_lib, dependencies: lib_deps)
 
 dtp_client_lib = library('dtpclient', client_src, include_directories: [include, include_directories('.')], dependencies: dtp_lib_dep, install: true)
-dtp_client_lib_dep = declare_dependency(include_directories : include, link_with : dtp_client_lib, dependencies: dtp_lib_dep).as_link_whole()
+dtp_client_lib_dep = declare_dependency(include_directories : include, link_with : dtp_client_lib, dependencies: dtp_lib_dep)
 
 dtp_server_lib = library('dtpserver', server_src, include_directories: [include, include_directories('.')], dependencies: dtp_lib_dep, install: true)
-dtp_server_lib_dep = declare_dependency(include_directories : include, link_with : dtp_server_lib, dependencies: dtp_lib_dep).as_link_whole()
+dtp_server_lib_dep = declare_dependency(include_directories : include, link_with : dtp_server_lib, dependencies: dtp_lib_dep)

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,20 +7,18 @@ lib_src = [
 client_src = [
     'dtp_client.c',
     'dtp_vmem_client.c',
-    'dtp_vmem_server.c',
 ]
 server_src = [
     'dtp_server.c',
+    'dtp_vmem_server.c',
     'payload_api.c'
 ]
 
-csp_dep = subproject('csp').get_variable('csp_dep').partial_dependency(links: false, includes: true)
-csp_dep_static = subproject('csp').get_variable('csp_dep')
-
+csp_dep = dependency('csp', fallback:['csp', 'csp_dep']).partial_dependency(links: false, includes: true)
 param_dep = dependency('param', fallback:['param', 'param_dep']).partial_dependency(links: false, includes: true)
-libsi_dep = dependency('si', fallback:['si', 'si_dep']).partial_dependency(links: false, includes: true)
+ossi_dep = dependency('ossi', fallback:['ossi', 'ossi_dep']) #.partial_dependency(links: false, includes: true)
 
-lib_deps = [csp_dep, param_dep, libsi_dep]
+lib_deps = [csp_dep, param_dep, ossi_dep]
 
 dtp_lib = library('dtp', lib_src, include_directories: [include, include_directories('.')], dependencies: lib_deps, install: true)
 dtp_lib_dep = declare_dependency(include_directories : include, link_with : dtp_lib, dependencies: lib_deps)

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ lib_src = [
 client_src = [
     'dtp_client.c',
     'dtp_vmem_client.c',
+    'dtp_vmem_server.c',
 ]
 server_src = [
     'dtp_server.c',
@@ -17,8 +18,9 @@ csp_dep = subproject('csp').get_variable('csp_dep').partial_dependency(links: fa
 csp_dep_static = subproject('csp').get_variable('csp_dep')
 
 param_dep = dependency('param', fallback:['param', 'param_dep']).partial_dependency(links: false, includes: true)
+libsi_dep = dependency('si', fallback:['si', 'si_dep']).partial_dependency(links: false, includes: true)
 
-lib_deps = [csp_dep, param_dep]
+lib_deps = [csp_dep, param_dep, libsi_dep]
 
 dtp_lib = library('dtp', lib_src, include_directories: [include, include_directories('.')], dependencies: lib_deps, install: true)
 dtp_lib_dep = declare_dependency(include_directories : include, link_with : dtp_lib, dependencies: lib_deps)

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ lib_src = [
 ]
 client_src = [
     'dtp_client.c',
+    'dtp_vmem_client.c',
 ]
 server_src = [
     'dtp_server.c',
@@ -15,7 +16,9 @@ server_src = [
 csp_dep = subproject('csp').get_variable('csp_dep').partial_dependency(links: false, includes: true)
 csp_dep_static = subproject('csp').get_variable('csp_dep')
 
-lib_deps = [csp_dep]
+param_dep = dependency('param', fallback:['param', 'param_dep']).partial_dependency(links: false, includes: true)
+
+lib_deps = [csp_dep, param_dep]
 
 dtp_lib = library('dtp', lib_src, include_directories: [include, include_directories('.')], dependencies: lib_deps, install: true)
 dtp_lib_dep = declare_dependency(include_directories : include, link_with : dtp_lib, dependencies: lib_deps)

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ server_src = [
 
 csp_dep = dependency('csp', fallback:['csp', 'csp_dep']).partial_dependency(links: false, includes: true)
 param_dep = dependency('param', fallback:['param', 'param_dep']).partial_dependency(links: false, includes: true)
-ossi_dep = dependency('ossi', fallback:['ossi', 'ossi_dep']) #.partial_dependency(links: false, includes: true)
+ossi_dep = dependency('ossi', fallback:['ossi', 'ossi_dep']).partial_dependency(links: false, includes: true)
 
 lib_deps = [csp_dep, param_dep, ossi_dep]
 

--- a/src/payload_api.c
+++ b/src/payload_api.c
@@ -34,6 +34,7 @@ __attribute__((weak)) bool get_payload_meta(dtp_payload_meta_t *meta, uint8_t pa
         /* deliberate fallthrough for now */
         default:
             /* 128 Mb for testing */
+            meta->base = 0;
             meta->size = 20 * 1024 * 1024;
             meta->read = payload_read;
         break;

--- a/src/payload_api.c
+++ b/src/payload_api.c
@@ -2,7 +2,7 @@
 #include <dtp/platform.h>
 
 static const char test_data[] = "0123456789ABCDE";
-static uint32_t payload_read(uint8_t payload_id, uint32_t offset, void *output, uint32_t size) {
+static uint32_t payload_read(uint8_t payload_id, uint32_t offset, void *output, uint32_t size, void *context) {
     uint32_t res = 0;
     switch(payload_id) {
         case 0:


### PR DESCRIPTION
The DTP has undergone a bit of work to be able to plugin easily into the VMEM request structure. This enables us to implement commands like `dtp_download <vaddr> <length> <filename>` is CSH and then have the `dtp_vmem_server.c` run in a background task. This will leave the VMEM server active, which makes it possible to send stop commands thru to the DTP transfer process. Work is still going into this, so further PR's might arise from this.