### PR TITLE
DTP keep alive: make keep alive interval configurable

### DIFF
--- a/include/dtp/dtp.h
+++ b/include/dtp/dtp.h
@@ -189,7 +189,7 @@ extern "C"
      */
     dtp_t *dtp_acquire_session();
 
-    dtp_t *dtp_prepare_session(uint32_t server, uint32_t session_id, uint32_t max_throughput, uint8_t timeout, uint8_t payload_id, void *ctx, uint16_t mtu, bool resume);
+    dtp_t *dtp_prepare_session(uint32_t server, uint32_t session_id, uint32_t max_throughput, uint8_t timeout, uint8_t payload_id, void *ctx, uint16_t mtu, bool resume, uint32_t keep_alive_interval);
 
     /**
      * Release a previously acquired handle on one of the pre-allocated sessions
@@ -303,7 +303,7 @@ extern "C"
     extern int dtp_vmem_server_main(dtp_async_api_t *api);
     extern int dtp_vmem_client_main(dtp_t *session);
     extern int dtp_server_main(bool *exit_server);
-    extern int dtp_client_main(uint32_t server, uint32_t max_throughput, uint8_t timeout, uint8_t payload_id, uint16_t mtu, bool resume, dtp_t **session, void *ctx);
+    extern int dtp_client_main(uint32_t server, uint32_t max_throughput, uint8_t timeout, uint8_t payload_id, uint16_t mtu, bool resume, dtp_t **session, void *ctx, uint32_t keep_alive_interval);
 
 /*
 #pragma endregion

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dtp', 'c', subproject_dir: 'extern', version: '0.0.1', default_options: [
+project('dtp', 'c', subproject_dir: 'extern', version: '0.0.2', default_options: [
   'default_library=static',
 	'b_lto=false',
   'b_lundef=false',

--- a/src/dtp_protocol.c
+++ b/src/dtp_protocol.c
@@ -19,6 +19,7 @@ dtp_result send_remote_meta_req(dtp_t *session)
         packet->length = sizeof(dtp_meta_req_t);
         dtp_meta_req_t *req = (dtp_meta_req_t *)packet->data;
         memcpy(req, &(session->request_meta), sizeof(dtp_meta_req_t));
+        req->keep_alive_interval = htobe32(session->request_meta.keep_alive_interval);
         csp_send(session->conn, packet);
         res = DTP_OK;
     }

--- a/src/dtp_server.c
+++ b/src/dtp_server.c
@@ -180,7 +180,7 @@ static bool dtp_server_poll_loop(uint32_t op, void *context) {
         csp_sendto(CSP_PRIO_NORM, transfer->ctx->destination, 8 /* DTP DATA PORT */, 0, 0, packet);
         transfer->nof_csp_packets++;
         pkt_cnt++;
-        if ((csp_get_ms() - transfer->ctx->client_alive_ts) > (transfer->ctx->request.keep_alive_interval * 2) + 500 ) {
+        if ((transfer->ctx->request.keep_alive_interval > 0) && (csp_get_ms() - transfer->ctx->client_alive_ts) > (transfer->ctx->request.keep_alive_interval * 2) + 500 ) {
             dbg_warn("Client no longer alive, aborting...\n");
             transfer->ctx->keep_running = false;
         }

--- a/src/dtp_vmem_client.c
+++ b/src/dtp_vmem_client.c
@@ -42,7 +42,7 @@ int vmem_request_dtp_start_download(dtp_t *session, int node, uint32_t session_i
     request->meta.throughput = htobe32(session->request_meta.throughput); /* Throughput in bytes/second */
     request->meta.mtu = htobe16(session->request_meta.mtu); /* MTU size (size of the *useful* payload DTP will use to split the payload) in BYTES */
     request->meta.session_id = htobe32(session_id); /* The session ID, representing this particular transfer */
-    request->meta.keep_alive_interval = htobe32(timeout * 1000); /* The session ID, representing this particular transfer */
+    request->meta.keep_alive_interval = htobe32(session->request_meta.keep_alive_interval); /* Keep alive interval, 0 means no keep alive */
     request->meta.nof_intervals = session->request_meta.nof_intervals; /* Number of intervals */
     if (request->meta.nof_intervals > (sizeof(request->meta.intervals) / sizeof(request->meta.intervals[0]))) {
         request->meta.nof_intervals = (sizeof(request->meta.intervals) / sizeof(request->meta.intervals[0]));


### PR DESCRIPTION
This change finishes the implementation of a "keep alive" feature in the DTP protocol.
It allows proper configuration of the keep alive packets that the client will send to the server to inform it that it is still alive. A value of 0 completely disables the keepalive mechanism entirely, should this be required.

Changes to the APM's using DTP (currently, csh_dtp & csh_cpstorage) will follow this PR